### PR TITLE
Forward reducer types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,6 @@ type Options = {
     persistThrottle: number;
     persistWholeStore: boolean;
 };
-declare const rememberReducer: (reducers: Reducer) => Reducer;
+declare const rememberReducer: <S, A extends Action<any>>(reducers: Reducer<S, A>) => Reducer<S, A>;
 declare const rememberEnhancer: <S, A extends Action<any>, Ext>(driver: Driver, rememberedKeys: string[], { prefix, serialize, unserialize, persistThrottle, persistWholeStore }?: Partial<Options>) => (createStore: StoreCreator) => (rootReducer: Reducer<S, A>, initialState?: PreloadedState<S> | undefined, enhancer?: StoreEnhancer<Ext, {}> | undefined) => import("redux").Store<S, A> & Ext;
 export { rememberReducer, rememberEnhancer, REMEMBER_REHYDRATED, REMEMBER_PERSISTED };


### PR DESCRIPTION
### The bug
Current type definition of `rememberReducer` doesn't preserve types.

Acknowledging redux's [reducer type definition](https://github.com/reduxjs/redux/blob/master/src/types/reducers.ts#L29 ):
```javascript
export type Reducer<S = any, A extends Action = AnyAction> = (
  state: S | undefined,
  action: A
) => S
```

Then current type definition
```javascript
declare const rememberReducer: (reducers: Reducer) => Reducer;
```
is equivalent to
```javascript
declare const rememberReducer: (reducers: Reducer<any, AnyAction>) => Reducer<any, AnyAction>
```

which ultimately results in type destruction

### What does this fix
Use generics params to enable type forwarding.
