### PR TITLE
Add simple debounce functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,5 +210,6 @@ API reference
             - **serialize** - a plain function that takes unserialized store state and its key (`serialize(state, stateKey)`) and returns serialized state to be persisted *(default: `JSON.stringify`)*;
             - **unserialize** - a plain function that takes serialized persisted state  and its key (`serialize(state, stateKey)`) and returns unserialized to be set in the store *(default: `JSON.parse`)*;
             - **persistThrottle** - how much time should the persistence be throttled in milliseconds *(default: `100`)*
+            - **persistDebounce** *(optional)* - how much time should the persistence be debounced by in milliseconds. If provided, persistence will not be throttled, and the `persistThrottle` option will be ignored. The debounce is a simple trailing-edge-only debounce.
             - **persistWholeStore** - a boolean which specifies if the whole store should be persisted at once. Generally only use this if you're using your own storage driver which has gigabytes of storage limits. Don't use this when using window.localStorage, window.sessionStorage or AsyncStorage as their limits are quite small. When using this option, key won't be passed to `serialize` nor `unserialize` functions - *(default: `false`)*;
     - Returns - an enhancer to be used with Redux

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,11 +12,9 @@ type Options = {
     serialize: SerializeFunction;
     unserialize: UnserializeFunction;
     persistThrottle: number;
+    persistDebounce?: number;
     persistWholeStore: boolean;
 };
-type ExtendedOptions = Options & {
-    driver: Driver;
-};
 declare const rememberReducer: <S = any, A extends Action<any> = AnyAction>(reducer: Reducer<S, A> | ReducersMapObject<S, A>) => Reducer<S, A>;
-declare const rememberEnhancer: (driver: Driver, rememberedKeys: string[], { prefix, serialize, unserialize, persistThrottle, persistWholeStore }?: Partial<Options>) => any;
-export { SerializeFunction, UnserializeFunction, Driver, Options, ExtendedOptions, rememberReducer, rememberEnhancer, REMEMBER_REHYDRATED, REMEMBER_PERSISTED };
+declare const rememberEnhancer: (driver: Driver, rememberedKeys: string[], { prefix, serialize, unserialize, persistThrottle, persistDebounce, persistWholeStore }?: Partial<Options>) => any;
+export { rememberReducer, rememberEnhancer, REMEMBER_REHYDRATED, REMEMBER_PERSISTED };

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,9 @@ type Options = {
     persistDebounce?: number;
     persistWholeStore: boolean;
 };
+type ExtendedOptions = Options & {
+    driver: Driver;
+};
 declare const rememberReducer: <S = any, A extends Action<any> = AnyAction>(reducer: Reducer<S, A> | ReducersMapObject<S, A>) => Reducer<S, A>;
 declare const rememberEnhancer: (driver: Driver, rememberedKeys: string[], { prefix, serialize, unserialize, persistThrottle, persistDebounce, persistWholeStore }?: Partial<Options>) => any;
-export { rememberReducer, rememberEnhancer, REMEMBER_REHYDRATED, REMEMBER_PERSISTED };
+export { SerializeFunction, UnserializeFunction, Driver, Options, ExtendedOptions, rememberReducer, rememberEnhancer, REMEMBER_REHYDRATED, REMEMBER_PERSISTED };

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -13,6 +13,7 @@ describe('init.ts', () => {
   let mockPersist: Partial<typeof persistModule>;
   let mockPick: Function;
   let mockThrottle: Function;
+  let mockDebounce: Function;
 
   let init: (...args: any[]) => any;
   let args: any[];
@@ -36,6 +37,7 @@ describe('init.ts', () => {
 
     mockPick = jest.fn((state: any) => state);
     mockThrottle = jest.fn((fn: any) => fn);
+    mockDebounce = jest.fn((fn: any) => fn);
 
     jest.mock(
       '../rehydrate.js',
@@ -51,7 +53,8 @@ describe('init.ts', () => {
       '../utils.js',
       () => ({
         pick: mockPick,
-        throttle: mockThrottle
+        throttle: mockThrottle,
+        debounce: mockDebounce
       })
     );
 
@@ -101,7 +104,7 @@ describe('init.ts', () => {
     );
   });
 
-  it('calls lodash.pick()', async () => {
+  it('calls pick()', async () => {
     await init(...args);
 
     expect(mockPick).toBeCalledWith(
@@ -110,7 +113,13 @@ describe('init.ts', () => {
     );
   });
 
-  it('calls lodash.throttle()', async () => {
+  it('calls throttle()', async () => {
+    await init(...args);
+
+    expect(mockPick).toBeCalledTimes(1);
+  });
+
+  it('calls debounce()', async () => {
     await init(...args);
 
     expect(mockPick).toBeCalledTimes(1);

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -57,4 +57,44 @@ describe('utils.ts', () => {
       expect(spy).lastCalledWith('fourth');
     });
   });
+
+  describe('debounce()', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    });
+
+    it('only calls after the debounce interval', () => {
+      const spy = jest.fn();
+      const debouncedSpy = utils.debounce(spy, 1000)
+      debouncedSpy()
+
+      expect(spy).not.toHaveBeenCalled()
+      
+      jest.advanceTimersByTime(500)
+      expect(spy).not.toHaveBeenCalled()
+      
+      jest.advanceTimersByTime(500)
+      expect(spy).toBeCalledTimes(1)
+    });
+
+    it('debounces, and only calls with the latest call arguments', () => {
+      const spy = jest.fn((value: number) => {});
+      const debouncedSpy = utils.debounce(spy, 1000)
+
+      for (let i = 0; i < 100; i++) {
+          debouncedSpy(i);
+      }
+
+      expect(spy).not.toHaveBeenCalled()
+
+      jest.runAllTimers();
+      expect(spy).toBeCalledTimes(1);
+      expect(spy).lastCalledWith(99)
+    });
+  })
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ const rememberEnhancer = (
     serialize = (data, key) => JSON.stringify(data),
     unserialize = (data, key) => JSON.parse(data),
     persistThrottle = 100,
+    persistDebounce,
     persistWholeStore = false
   }: Partial<Options> = {}
 ): any => {
@@ -88,7 +89,7 @@ const rememberEnhancer = (
     init(
       store,
       rememberedKeys,
-      { driver, prefix, serialize, unserialize, persistThrottle, persistWholeStore }
+      { driver, prefix, serialize, unserialize, persistThrottle, persistDebounce, persistWholeStore }
     );
 
     return store;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export type Options = {
   serialize: SerializeFunction,
   unserialize: UnserializeFunction,
   persistThrottle: number,
+  persistDebounce?: number,
   persistWholeStore: boolean
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,3 +50,19 @@ export const throttle = <T extends (...args: any) => void>(
     }, timeLeft);
   }) as T;
 };
+
+export const debounce = <T extends (...args: any) => void>(
+  callback: T,
+  msecs: number
+): T => {
+  let nextCallTimeout: TimeoutHandle | null;
+
+  return ((...args: any): void => {
+    clearTimeout(nextCallTimeout as TimeoutHandle);
+
+    nextCallTimeout = setTimeout(() => {
+      callback(...args);
+      nextCallTimeout = null;
+    }, msecs);
+  }) as T;
+};


### PR DESCRIPTION
- Add simple debounce functionality
- If `persistDebounce` is provided, calls to persist will be debounced by the given amount of time and not throttled
- If it is not provided, behaviour is idential (e.g. throttle), so this is a non-breaking change
- Add tests for it
- Update README

---

We have a use-case for debouncing calls to the persist function - we want to totally avoid persistence-related execution until there is no change to state for X ms.

The persistence process has its own overhead before the storage driver is called, and we want to debounce that, so a debounced storage driver is not an option.

I'm not sure how to get that last little bit of test coverage and it bugs me!

I'm happy to extend this to be a more full-featured debounce (comparable to lodash) if that's desired. Another idea I had was to optionally accept a `persist()` wrapper function - so you could just pass lodash throttle/debounce and use that to wrap the persist call.