### PR TITLE
docs: update readme for react native custom driver example

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ export const customDriver: Driver = {
       return SecureStore.setItemAsync(originalKey, value);
     }
 
-    return AsyncStorage.setItem(key, value);
+    return AsyncStorage.setItem(originalKey, value);
   },
   getItem(key: string) {
     const originalKey = key.slice(prefix.length);
@@ -186,7 +186,7 @@ export const customDriver: Driver = {
       return SecureStore.getItemAsync(originalKey);
     }
 
-    return AsyncStorage.getItem(key);
+    return AsyncStorage.getItem(originalKey);
   }
 };
 


### PR DESCRIPTION
# What's the change?

Little update to the custom driver example so it uses the `originalKey` to store and retrieve the item, like it shows for secure store :) 