### PR TITLE
feat: add state reconciler option

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ API reference
         1. **driver** *(required)* - storage driver instance, that implements the `setItem(key, value)` and `getItem(key)` functions;
         2. **rememberedKeys** *(required)* - an array of persistable keys - if an empty array is provided nothing will get persisted;
         3. **options** *(optional)* - plain object of extra options:
-            - **prefix**: storage key prefix *(default: `'@@remember-'`)*;
+            - **prefix** - storage key prefix *(default: `'@@remember-'`)*;
             - **serialize** - a plain function that takes unserialized store state and its key (`serialize(state, stateKey)`) and returns serialized state to be persisted *(default: `JSON.stringify`)*;
             - **unserialize** - a plain function that takes serialized persisted state  and its key (`serialize(state, stateKey)`) and returns unserialized to be set in the store *(default: `JSON.parse`)*;
             - **persistThrottle** - how much time should the persistence be throttled in milliseconds *(default: `100`)*
@@ -312,4 +312,5 @@ API reference
             - **persistWholeStore** - a boolean which specifies if the whole store should be persisted at once. Generally only use this if you're using your own storage driver which has gigabytes of storage limits. Don't use this when using window.localStorage, window.sessionStorage or AsyncStorage as their limits are quite small. When using this option, key won't be passed to `serialize` nor `unserialize` functions - *(default: `false`)*;
             - **errorHandler** - an error handler hook function which is gets a first argument of type `PersistError` or `RehydrateError` - these include a full error stack trace pointing to the source of the error. If this option isn't specified the default behaviour is to log the error using console.warn() - *(default: `console.warn`)*;
             - **initActionType** (optional) - a string which allows you to postpone the initialization of `Redux Remember` until an action with this type is dispatched to the store. This is used in special cases whenever you want to do something before state gets rehydrated and persisted automatically (e.g. preload your state from SSR). **NOTE: With this option enabled Redux Remember will be completely disabled until `dispatch({ type: YOUR_INIT_ACTION_TYPE_STRING })` is called**;
+            - **stateReconciler** (optional) - a plain function that takes the current state and the driver loaded state (`stateReconciler(currentState, loadedState)`) and returns a new state. This can be used to deeply merge the two states before it's dispatched through the `REMEMBER_REHYDRATED` action.
     - Returns - an enhancer to be used with Redux

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ const rememberEnhancer = <Ext extends {} = {}, StateExt extends {} = {}>(
     prefix = '@@remember-',
     serialize = (data, key) => JSON.stringify(data),
     unserialize = (data, key) => JSON.parse(data),
+    stateReconciler,
     persistThrottle = 100,
     persistDebounce,
     persistWholeStore = false,
@@ -91,7 +92,8 @@ const rememberEnhancer = <Ext extends {} = {}, StateExt extends {} = {}>(
         persistThrottle,
         persistDebounce,
         persistWholeStore,
-        errorHandler
+        errorHandler,
+        stateReconciler,
       }
     );
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -17,13 +17,14 @@ const init = async (
     persistThrottle,
     persistDebounce,
     persistWholeStore,
-    errorHandler
+    errorHandler,
+    stateReconciler,
   }: ExtendedOptions
 ) => {
   await rehydrate(
     store,
     rememberedKeys,
-    { prefix, driver, unserialize, persistWholeStore, errorHandler }
+    { prefix, driver, unserialize, persistWholeStore, errorHandler, stateReconciler }
   );
 
   let oldState = {};

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import { PersistError, RehydrateError } from './errors';
 
 export type SerializeFunction = (data: any, key: string) => any;
 export type UnserializeFunction = (data: any, key: string) => any;
+export type StateReconcilerFunction = (currentState: any, loadedState: any) => any;
 
 export type Driver = {
   getItem: (key: string) => any;
@@ -12,6 +13,7 @@ export type Options = {
   prefix: string,
   serialize: SerializeFunction,
   unserialize: UnserializeFunction,
+  stateReconciler?: StateReconcilerFunction,
   persistThrottle: number,
   persistDebounce?: number,
   persistWholeStore: boolean,


### PR DESCRIPTION
# What's the feature?

Add a `stateReconciler` option (plain function) so that the driver loaded state and current state can be merged in a custom way before being dispatched by the `REMEMBER_REHYDRATED` action. This means we provide flexibility for consumers if they want to deeply merge the state similar to `redux-persist`. 

## Example

```ts
import { merge } from 'lodash';

rememberEnhancer(rememberConfig.driver, rememberConfig.rememberedKeys, {
   stateReconciler: (currentState, loadedState) => merge({}, currentState, loadedState),
})
```

## Checklist

- [x] Added test to cover `stateReconciler`
- [x] Updated doc in the README for the new option 

Covers #7 