### PR TITLE
Fix rehydration race condition with async drivers (e.g. IndexedDB)

### DIFF
--- a/packages/redux-remember/src/index.ts
+++ b/packages/redux-remember/src/index.ts
@@ -37,7 +37,7 @@ const rememberReducer = <S = any, A extends Action = UnknownAction, PreloadedSta
     switch (action.type) {
       case REMEMBER_REHYDRATED: {
         const rehydratedState = {
-          ...data.state,
+          ...state,
           ...(action?.payload || {})
         };
 

--- a/packages/redux-remember/src/rehydrate.ts
+++ b/packages/redux-remember/src/rehydrate.ts
@@ -68,7 +68,7 @@ export const rehydrate = async (
     migrate
   }: RehydrateOptions
 ) => {
-  let state = store.getState();
+  let loadedData: Record<string, any> = {};
   let rehydrated = false;
 
   try {
@@ -76,21 +76,23 @@ export const rehydrate = async (
       ? loadAll
       : loadAllKeyed;
 
-    state = {
-      ...state,
-      ...await load({
-        rememberedKeys,
-        driver,
-        prefix,
-        unserialize
-      })
-    };
+    loadedData = await load({
+      rememberedKeys,
+      driver,
+      prefix,
+      unserialize
+    });
 
     rehydrated = true;
   } catch (err) {
     errorHandler(new RehydrateError(err));
     rehydrated = false;
   }
+
+  let state = {
+    ...store.getState(),
+    ...loadedData
+  };
 
   if (rehydrated) {
     try {


### PR DESCRIPTION
When using an async storage driver (like IndexedDB), the `rehydrate` function calls `store.getState()` before awaiting the storage load. If any actions are dispatched while the load is in-flight (e.g. RTK Query registering endpoints, middleware running), those state changes get overwritten when the rehydrated state is dispatched.

There's a related issue in `rememberReducer` — the `REMEMBER_REHYDRATED` case spreads `data.state` (a snapshot captured at `@@INIT` time) instead of the current `state` parameter.